### PR TITLE
fix for issue #5 - https://github.com/Doloops/mcachefs/issues/5

### DIFF
--- a/src/mcachefs-metadata.c
+++ b/src/mcachefs-metadata.c
@@ -94,6 +94,12 @@ mcachefs_metadata_do_get(mcachefs_metadata_id id)
         mcachefs_metadata_mmap_block(block);
     }
 
+    // we have to check if the corresponding block for the given ID
+    // exists, unless we have to return NULL
+    // https://github.com/Doloops/mcachefs/issues/5
+    if ( block >= metadata_map_mmap_count ){
+      return NULL;
+    }
     metadata_map[block].last_used = mcachefs_get_jiffy_sec();
     struct mcachefs_metadata_t *meta =
         (struct mcachefs_metadata_t *) ((unsigned long)
@@ -1309,7 +1315,10 @@ mcachefs_metadata_clean_fh_locked(mcachefs_metadata_id id)
     if (id)
     {
         mdata = mcachefs_metadata_do_get(id);
-        mdata->fh = 0;
+        // we have to check if pointer exists, in case metadata was flushed
+        // issue #5 - https://github.com/Doloops/mcachefs/issues/5
+        if (mdata)
+          mdata->fh = 0;
     }
 }
 

--- a/testing/testing-fclose-after-flush.py
+++ b/testing/testing-fclose-after-flush.py
@@ -1,0 +1,50 @@
+#!/bin/env python
+
+
+import os, sys, subprocess, shlex, time
+
+BASEPATH = "/tmp/mcachefs.testing"
+MCACHEFS = os.path.dirname( os.path.abspath(__file__) )+'/../src/mcachefs'
+
+
+os.system('mkdir -p '+BASEPATH+"/1")
+os.system('mkdir -p '+BASEPATH+"/2")
+
+# just make sure mcachefs is not mounted, in case we're running after a failed try
+os.system("fusermount -u %s/2" % BASEPATH)
+
+# run mcachefs in gdb so we can see a stack trace in case it fails!
+cmd='''/bin/sh -c "echo -e 'r\\nbt\\n' | gdb --args %s -f -o -s %s/1 %s/2" ''' % (MCACHEFS, BASEPATH, BASEPATH)
+p = subprocess.Popen(shlex.split(cmd))
+
+print shlex.split(cmd), p.pid
+if not p.pid:
+    print "Failed to run %s!" % MCACHEFS
+    sys.exit(-1)
+
+# wait a bit mcachefs to mount!
+while( not os.path.exists('%s/2/.mcachefs' % BASEPATH) ):
+    time.sleep(1)
+
+# create 300 files
+for n in range(300):
+    open('%s/2/%s' % (BASEPATH, n),'w').close()
+
+# open the last one!
+f=open('%s/2/%s' % (BASEPATH, n-1) )
+
+# flush metadata
+os.system('echo flush_metadata >  %s/2/.mcachefs/action' % BASEPATH)
+
+# close the opened file. It should NOT crash!
+f.close()
+
+# kill gdb if it's still running!
+p.poll()
+if not p.returncode:
+    p.kill()
+
+# unmount mcachefs
+os.system("fusermount -u %s/2" % BASEPATH)
+os.system('rm -rf '+BASEPATH+"/1")
+os.system('rm -rf '+BASEPATH+"/2")


### PR DESCRIPTION
after a metadata flush, if we try to close a file descriptor that
was open before the flush, and that file have a metadata ID that
belongs to a metadata block that was removed by the flush, we
have to check for that in mcachefs_metadata_do_get() and return
NULL for the corresponding metadata, so the function that requested
it can deal with it properly!

this fixes a crash happening in issue #5, since
mcachefs_metadata_clean_fh_locked() will now check if the mdata
pointer is NULL before trying to use it.