### PR TITLE
added pre mount and umount custom command arguments

### DIFF
--- a/src/mcachefs-config.h
+++ b/src/mcachefs-config.h
@@ -68,6 +68,10 @@ struct mcachefs_config
     char *cache_prefix;
 
     char *cleanup_cache_prefix;
+
+    char *pre_mount_cmd;
+
+    char *pre_umount_cmd;
 };
 
 struct mcachefs_config *mcachefs_parse_config(int argc, char *argv[]);
@@ -132,5 +136,14 @@ const char *mcachefs_config_get_cleanup_cache_prefix();
 
 const char *mcachefs_config_get_cache_prefix();
 void mcachefs_config_set_cache_prefix(const char *prefix);
+
+
+/**
+ * run custom commands before mount and umount
+ */
+int mcachefs_config_run_cmd(const char *cmd);
+int mcachefs_config_run_pre_mount_cmd();
+int mcachefs_config_run_pre_umount_cmd();
+
 
 #endif // __MCACHEFS_CONFIG_H

--- a/src/mcachefs-lowlevel.c
+++ b/src/mcachefs-lowlevel.c
@@ -718,6 +718,7 @@ mcachefs_destroy(void *conn)
 
     mcachefs_file_stop_thread();
     mcachefs_transfer_stop_threads();
+    mcachefs_config_run_pre_umount_cmd();
 }
 
 struct fuse_operations mcachefs_oper =

--- a/src/mcachefs.c
+++ b/src/mcachefs.c
@@ -33,6 +33,8 @@ main(int argc, char *argv[])
 
     mcachefs_set_current_config(config);
 
+    mcachefs_config_run_pre_mount_cmd();
+
     mcachefs_file_timeslice_init_variables();
 
 

--- a/src/mcachefs.c
+++ b/src/mcachefs.c
@@ -33,7 +33,11 @@ main(int argc, char *argv[])
 
     mcachefs_set_current_config(config);
 
-    mcachefs_config_run_pre_mount_cmd();
+    if ( mcachefs_config_run_pre_mount_cmd() != 0 )
+    {
+      Info("Pre-mount command failed!!\n");
+      return 1;
+    }
 
     mcachefs_file_timeslice_init_variables();
 


### PR DESCRIPTION
using pre-mount-cmd and pre-umount-cmd, we can make mcachefs mount the source folder automatically when it's mounted, and umount the source folder once mcachefs is umounted. 

For example: mcachefs -o pre-mount-cmd='mkdir -p /source_folder ; sshfs <server>:/source_folder /source_folder', pre-umount-cmd='sudo umount /source_folder ; rmdir /source_folder'  /source_folder /backed_folder

this enables mcachefs to be used with autofs smoothly. 

todo: add post-mount-cmd to execute a cmd right after mcachefs has being mounted. For example, "echo flush_metadata > /backed_fs/.mcachefs/action"