### PR TITLE
updating previously cached files when they are updated in the backend.

### DIFF
--- a/src/mcachefs-transfer.c
+++ b/src/mcachefs-transfer.c
@@ -421,8 +421,9 @@ mcachefs_transfer_do_backing(struct mcachefs_file_t *mfile)
 
     if (mcachefs_fileincache(mfile->path))
     {
-        Err("File '%s' already in cache !\n", mfile->path);
-        return;
+        // Err("File '%s' already in cache !\n", mfile->path);
+        // return;
+        Info("File '%s' already in cache but is older than the one in the source.\n", mfile->path);
     }
     if (mcachefs_createfile_cache(mfile->path, 0644))
     {


### PR DESCRIPTION
when re-mounting mcachefs with previously cached files, originally mcachefs_transfer_do_backing detects a file already in cache and would throw an error, forcing mcachefs to always use the source file instead of updating the local cache. 

This change just reports that the already cached file exists and it's older than the source, and instead of returning and forcing mcachefs to use the source file, it will continue and update the file in the cache, so subsequent reading will be done from the cache as it should.